### PR TITLE
Added support for new firmware 7.12

### DIFF
--- a/ArgumentParser.py
+++ b/ArgumentParser.py
@@ -41,7 +41,7 @@ class ArgumentParser():
 	def __init__(self):
 		self._parser = FriendlyArgumentParser(prog = sys.argv[0], description = "Tool to communicate with Gamma Scout geiger counters and read out the radiation log", add_help = False)
 		self._parser.add_argument("-d", "--device", metavar = "device", type = str, default = "/dev/ttyUSB0", help = "Specifies the device that the Gamma Scout is connected to. For debugging purposes, 'sim' may be specified to include simulation sources. Default is %(default)s")
-		self._parser.add_argument("-p", "--protocol", metavar = "version", type = str, choices = [ "v1", "v2" ], default = "v2", help = "Specifies the device protocol the connected Gamma Scout uses. Older models use v1 while newer versions use v2. Possible options are %(choices)s, default is %(default)s")
+		self._parser.add_argument("-p", "--protocol", metavar = "version", type = str, choices = [ "v1", "v2_9600", "v2_460800" ], default = "v2_460800", help = "Specifies the device protocol the connected Gamma Scout uses. Older models use v1 (FW < 6.00) while newer versions use v2_9600 (9600 baud, 6.00 <= FW < 6.90) or v2_460800 (460800 baud, FW >= 6.90). Possible options are %(choices)s, default is %(default)s")
 		self._parser.add_argument("--simulate", action = "store_true", help = "Do not connect to a real Gamma Scout device, but connect to a simulator (device name should be UNIX socket)")
 		self._parser.add_argument("--force", action = "store_true", help = "Allow execution of commands that are not usually needed by the user (you should only use this if you know what you're doing)")
 		self._parser.add_argument("-v", "--verbose", action = "count", default = 0, help = "Show mode logging info. May be specified multiple times to increasse verbosity")

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,7 +27,11 @@ Summary of changes from v0.04 to v0.05 (2013-xx-xx)
 	* Bugfix in TXT output backend (CPS and CPM are swithced)
 	* Bugfix when count values overflow (thanks to Erik Berglund for reporting
 	this)
-
+	* Added support for 460k8 baudrate for v2 devices
+	* Added new 6 byte timestamp encoding, which implements second
+	representation additionally
+	* Added new event flags for Standard Conversion Data Set (Cs137) and
+	Alternative Conversion Data Set (Co60)
 
 Summary of changes from v0.03 to v0.04 (2012-01-06)
 ===================================================

--- a/GSProtocolHandlerVers2.py
+++ b/GSProtocolHandlerVers2.py
@@ -35,7 +35,7 @@ from RE import RE
 OnlineResults = collections.namedtuple("OnlineResults", [ "utctimestamp", "interval", "counts" ])
 
 class GSProtocolHandlerVers2(GSProtocolHandler):
-	_version_pc_regex = RE("Version ([0-9]\.[0-9]{2}) " + RE.GDECIMAL + " " + RE.GHEXADECIMAL + " ([0-9]{2})\.([0-9]{2})\.([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})")
+	_version_pc_regex = RE("Version ([0-9]\.[0-9A-Za-z]{2,6}) " + RE.GDECIMAL + " " + RE.GHEXADECIMAL + " ([0-9]{2})\.([0-9]{2})\.([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})")
 	_version_v1_regex = re.compile("^ Version (?P<version>[0-9]\.[0-9]{2})$")
 	_config_firstline_regex = RE(RE.GHEXADECIMAL + " " + RE.GHEXADECIMAL + " " + RE.GHEXADECIMAL)
 	_online_regex = re.compile("^I(?P<interval>[0-9a-f]{4})(?P<counts>[0-9a-f]{6})$")

--- a/GammaCommands.py
+++ b/GammaCommands.py
@@ -46,8 +46,9 @@ class GammaCommands():
 		self._log = logging.getLogger("gsu.cmds." + self.__class__.__name__)
 		self._args = args
 		self._protocolhandler = {
-			"v1":		GSProtocolHandlerVers1,
-			"v2":		GSProtocolHandlerVers2,
+			"v1":			GSProtocolHandlerVers1,
+			"v2_9600":		GSProtocolHandlerVers2,
+			"v2_460800":	GSProtocolHandlerVers2,
 		}[args["protocol"]]
 		self._conn = None
 		self._device = None
@@ -125,8 +126,9 @@ class GammaCommands():
 		backend = backendclass(filename, self._args)
 		backend.initdata(logsize, logdata)
 		parserclass = {
-			"v1":		LogDataParserVers1,
-			"v2":		LogDataParserVers2,
+			"v1":			LogDataParserVers1,
+			"v2_9600":		LogDataParserVers2,
+			"v2_460800":	LogDataParserVers2,
 		}[self._args["protocol"]]
 		parserclass(logdata, backend).parse(logsize)
 		backend.close()

--- a/GammaPlot/CmdLineParser.py
+++ b/GammaPlot/CmdLineParser.py
@@ -503,7 +503,7 @@ if __name__ == "__main__":
 	c.addoption(o)
 
 	o = CmdLineOption("protocol", "p", "protocol").setdescription("This is a protocol definition of some kind")
-	o.setoccurence(1).settakesparameters(True, "protocol").setparser(EnumParser(set([ "v1", "v2", "legacy" ])))
+	o.setoccurence(1).settakesparameters(True, "protocol").setparser(EnumParser(set([ "v1", "v2_9600", "v2_460800", "legacy" ])))
 	c.addoption(o)
 
 	o = CmdLineOption("otherstuff", "q", None).setdescription("This is some datetime option")

--- a/LogDataParserVers2.py
+++ b/LogDataParserVers2.py
@@ -47,6 +47,13 @@ class LogDataParserVers2(LogDataParser):
 					year += 2000
 					self._log.debug("0x%x: Set Date: %04d-%02d-%02d %2d:%02d" % (self._offset, year, month, day, hour, minute))
 					self._curdate = datetime.datetime(year, month, day, hour, minute)
+				if peek == 0xed:
+					data = self._nextbytes(7)[1:]
+					data = LogDataParser._hexdecify(data)
+					(second, minute, hour, day, month, year) = data
+					year += 2000
+					self._log.debug("0x%x: Set Date: %04d-%02d-%02d %2d:%02d:%02d" % (self._offset, year, month, day, hour, minute, second))
+					self._curdate = datetime.datetime(year, month, day, hour, minute, second)
 				elif peek == 0xee:
 					data = self._nextbytes(5)[1:]
 					gap = ((data[1] << 8) | data[0]) * 10
@@ -105,6 +112,12 @@ class LogDataParserVers2(LogDataParser):
 					self._log.debug("0x%x: Interval 7 days" % (self._offset))
 					self._nextbytes(1)
 					self._interval = 7 * 86400
+				elif peek == 0xea:
+					self._log.debug("0x%x: Standard conversion data set (Cs137) active" % (self._offset))
+					self._nextbytes(1)
+				elif peek == 0xeb:
+					self._log.debug("0x%x: Alternative conversion data set (Co60) active" % (self._offset))
+					self._nextbytes(1)
 				elif peek == 0xf3:
 					self._log.warn("0x%x: Unknown command 0xf3" % (self._offset))
 					self._nextbytes(1)

--- a/RS232Connection.py
+++ b/RS232Connection.py
@@ -32,8 +32,9 @@ class RS232Connection(GSConnection):
 		GSConnection.__init__(self, args)
 		self._log = logging.getLogger("gsu.traffic." + self.__class__.__name__)
 		baudrate = {
-			"v1":		2400,
-			"v2":		9600,
+			"v1":			2400,
+			"v2_9600":		9600,
+			"v2_460800":	460800
 		}[args["protocol"]]
 		self._conn = serial.Serial(args["device"], baudrate = baudrate, bytesize = 7, parity = "E", stopbits = 1, timeout = 0.1)
 		self._rxthread = RS232ReaderThread(self._conn, self._rxbuf.push)


### PR DESCRIPTION
Following things needed to be added, in order to support newer devices:

- Added new flag handling for Cs137 and Co60 conversion data set
- Added support for new timestamp format
- Fixed regex for new firmware format